### PR TITLE
Add Xiao ESP32-S3 LoRa display firmware example

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -1,0 +1,79 @@
+# Firmware: Xiao ESP32-S3 + Wio-SX1262 + 2.0" ST7789V (240x320)
+
+Ten katalog zawiera przykładowy firmware w Arduino/PlatformIO, który łączy mikrokontroler Seeed Studio Xiao ESP32-S3 z modemem LoRa Wio-SX1262 oraz wyświetlaczem TFT 2.0" ST7789V 240x320. Projekt demonstruje:
+
+- inicjalizację i prosty ekran startowy na ST7789,
+- konfigurację radia SX1262 (biblioteka RadioLib) i cykliczne wysyłanie komunikatu,
+- współdzielenie jednej magistrali SPI dla radia i wyświetlacza.
+
+## Wymagania
+- PlatformIO (CLI lub w VS Code)
+- Płytka: `seeed_xiao_esp32s3`
+- Biblioteki: `Adafruit GFX`, `Adafruit ST7735 and ST7789`, `RadioLib`
+
+## Schemat połączeń (tekstowy)
+Wszystkie urządzenia pracują na jednej magistrali SPI. Linie zasilania (3V3, GND) pominięto dla czytelności.
+
+### Wspólne sygnały SPI
+| Sygnał | ESP32-S3 | ST7789V | Wio-SX1262 |
+| --- | --- | --- | --- |
+| SCK | GPIO6 (D5) | SCK | SCK |
+| MOSI | GPIO7 (D6) | SDA/MOSI | MOSI |
+| MISO | GPIO8 (D7) | (nieużywane) | MISO |
+
+### Linie sterujące
+| Funkcja | ESP32-S3 | ST7789V | Wio-SX1262 |
+| --- | --- | --- | --- |
+| CS (LCD) | GPIO5 (D4) | CS | — |
+| DC (LCD) | GPIO4 (D3) | DC | — |
+| RST (LCD) | GPIO3 (D2) | RST | — |
+| BL (LCD) | GPIO2 (D1) | BL | — |
+| CS (LoRa) | GPIO1 (D0) | — | NSS |
+| RST (LoRa) | GPIO10 (D9) | — | NRESET |
+| DIO1 (LoRa) | GPIO21 (D10) | — | DIO1 |
+| BUSY (LoRa) | GPIO9 (D8) | — | BUSY |
+
+> Uwagi: pin G9 (D8) w Xiao ESP32-S3 jest bezpieczny do użycia jako wejście/wyjście. Jeżeli używasz innej rewizji, zweryfikuj mapowanie pinów w dokumentacji Seeed.
+
+### Prosty obraz połączeń
+Mermaid pokazuje przebieg sygnałów; w podglądzie Markdown w VS Code/PlatformIO zostanie wygenerowany schemat.
+
+```mermaid
+graph LR
+    subgraph SPI\n(shared)
+    SCK((GPIO6/D5)) -- SCK --> ST7789SCK
+    SCK -- SCK --> SX1262SCK
+    MOSI((GPIO7/D6)) -- MOSI --> ST7789MOSI
+    MOSI -- MOSI --> SX1262MOSI
+    MISO((GPIO8/D7)) -- MISO --> SX1262MISO
+    end
+
+    subgraph LCD
+    LCDCS((GPIO5/D4)) -- CS --> ST7789CS
+    LCDDC((GPIO4/D3)) -- DC --> ST7789DC
+    LCDRST((GPIO3/D2)) -- RST --> ST7789RST
+    LCDBL((GPIO2/D1)) -- BL --> ST7789BL
+    end
+
+    subgraph LoRa
+    LORACS((GPIO1/D0)) -- NSS --> SX1262CS
+    LORARST((GPIO10/D9)) -- RESET --> SX1262RST
+    LORADIO1((GPIO21/D10)) -- DIO1 --> SX1262DIO1
+    LORABUSY((GPIO9/D8)) -- BUSY --> SX1262BUSY
+    end
+```
+
+## Kompilacja i wgrywanie
+1. Zainstaluj zależności: `pio pkg install` (opcjonalnie, biblioteki są zadeklarowane w `platformio.ini`).
+2. Zbuduj: `pio run`.
+3. Wgraj: `pio run -t upload` (upewnij się, że port szeregowy jest poprawnie wykryty).
+
+## Konfiguracja radiowa
+Domyślna częstotliwość to 868.0 MHz (EU868). W pliku `src/main.cpp` dostosuj `LORA_FREQ` oraz parametry `setBandwidth`, `setSpreadingFactor`, `setCodingRate` do wymagań lokalnych i prawnych.
+
+## Plik źródłowy
+Główna logika znajduje się w `src/main.cpp` i obejmuje:
+- inicjalizację SPI dla LCD i LoRa,
+- renderowanie ekranu powitalnego,
+- rozpoczęcie pracy radia SX1262 i cykliczne wysyłanie ramki co 10 sekund,
+- wyświetlanie statusu na LCD oraz przez port szeregowy.

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -1,0 +1,15 @@
+[env:seeed_xiao_esp32s3]
+platform = espressif32
+board = seeed_xiao_esp32s3
+framework = arduino
+monitor_speed = 115200
+
+lib_deps =
+    adafruit/Adafruit GFX Library@^1.11.10
+    adafruit/Adafruit ST7735 and ST7789 Library@^1.10.4
+    jgromes/RadioLib@^6.5.0
+
+build_flags =
+    -D LORA_FREQ=868.0
+    -D TFT_RGB_ORDER=TFT_RGB
+    -D ST7789_DRIVER

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -1,0 +1,108 @@
+#include <Arduino.h>
+#include <SPI.h>
+#include <Adafruit_GFX.h>
+#include <Adafruit_ST7789.h>
+#include <RadioLib.h>
+
+// --- Pin map ---
+// SPI shared bus
+constexpr int TFT_SCK = 6;   // D5
+constexpr int TFT_MOSI = 7;  // D6
+constexpr int TFT_MISO = 8;  // D7 (LCD nie używa, ale wymagany przez SPI)
+constexpr int LORA_SCK = TFT_SCK;
+constexpr int LORA_MOSI = TFT_MOSI;
+constexpr int LORA_MISO = TFT_MISO;
+
+// TFT control
+constexpr int TFT_CS = 5;   // D4
+constexpr int TFT_DC = 4;   // D3
+constexpr int TFT_RST = 3;  // D2
+constexpr int TFT_BL = 2;   // D1
+
+// SX1262 control
+constexpr int LORA_CS = 1;    // D0
+constexpr int LORA_RST = 10;  // D9
+constexpr int LORA_DIO1 = 21; // D10 (wejście przerwania)
+constexpr int LORA_BUSY = 9;  // D8
+
+#ifndef LORA_FREQ
+#define LORA_FREQ 868.0
+#endif
+
+SPIClass sharedSPI(FSPI);
+Adafruit_ST7789 tft(&sharedSPI, TFT_CS, TFT_DC, TFT_RST);
+SX1262 radio = new Module(LORA_CS, LORA_DIO1, LORA_RST, LORA_BUSY);
+
+uint32_t lastSend = 0;
+const uint32_t sendIntervalMs = 10'000;
+
+void drawSplash(const char* statusText) {
+  tft.fillScreen(ST77XX_BLACK);
+  tft.setTextColor(ST77XX_WHITE);
+  tft.setTextSize(2);
+  tft.setCursor(10, 20);
+  tft.println("XIAO ESP32-S3");
+  tft.setTextSize(1);
+  tft.println("Wio-SX1262 + ST7789V");
+  tft.println("Demo firmware");
+
+  tft.setCursor(10, 100);
+  tft.setTextColor(ST77XX_CYAN);
+  tft.setTextSize(2);
+  tft.println("Status:");
+  tft.setTextSize(1);
+  tft.setTextColor(ST77XX_YELLOW);
+  tft.println(statusText);
+}
+
+void appendLog(const String& line) {
+  Serial.println(line);
+  tft.fillRect(0, 180, 240, 140, ST77XX_BLACK);
+  tft.setCursor(10, 180);
+  tft.setTextColor(ST77XX_GREEN);
+  tft.setTextSize(1);
+  tft.print("Last: ");
+  tft.println(line);
+}
+
+void setup() {
+  pinMode(TFT_BL, OUTPUT);
+  digitalWrite(TFT_BL, HIGH);
+
+  Serial.begin(115200);
+  delay(200);
+
+  // Start shared SPI (LCD first to get splash screen quickly)
+  sharedSPI.begin(TFT_SCK, TFT_MISO, TFT_MOSI, TFT_CS);
+
+  tft.init(240, 320);
+  tft.setRotation(2); // zależnie od montażu można zmienić na 0-3
+  drawSplash("Inicjalizacja...");
+
+  // Konfiguracja radia SX1262
+  radio.setSPI(&sharedSPI);
+  int state = radio.begin(LORA_FREQ);
+  if (state == RADIOLIB_ERR_NONE) {
+    radio.setBandwidth(125.0);
+    radio.setSpreadingFactor(7);
+    radio.setCodingRate(5);
+    radio.setOutputPower(14);
+    appendLog("Radio OK @" + String(LORA_FREQ, 1) + "MHz");
+  } else {
+    appendLog("Radio error: " + String(state));
+  }
+}
+
+void loop() {
+  if (millis() - lastSend >= sendIntervalMs) {
+    lastSend = millis();
+    String payload = "HELLO @" + String(lastSend);
+
+    int state = radio.transmit(payload);
+    if (state == RADIOLIB_ERR_NONE) {
+      appendLog("TX OK: " + payload);
+    } else {
+      appendLog("TX fail: " + String(state));
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add PlatformIO project skeleton for Seeed Xiao ESP32-S3 pairing SX1262 and ST7789V
- document SPI wiring with tables and mermaid diagram for pin connections
- include Arduino firmware that initializes the display and sends periodic LoRa packets using RadioLib

## Testing
- not run (not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69401d4b1c648323a328a214ffa5e4e0)